### PR TITLE
Refactor to allow for multiple instances of consumer and publisher to exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,22 +98,25 @@ Check out the [examples](examples) for more details of the basic, advanced, adva
 
 - `processMessage`: The function to handle processing the RPC request. Can standard Javascript Function or return a fulfilled Promise.
 - `connectionRetryInterval`: default: 500ms
-- `url`: default: 'localhost'
-- `socketOptions`: default empty Object
+- `url`: default: 'localhost' - [A valid amqp URI](https://www.rabbitmq.com/uri-spec.html).
+- `socketOptions`: default empty Object - The socket options will be passed to the socket library (net or tls). The socket options may also include the key noDelay, with a boolean value. If the value is true, this sets TCP_NODELAY on the underlying socket.
 - `queue`: default: 'node_rpc_queue'
+- `queueOptions` : default: ````{durable: true}```` - AMQP options passed to the queue. You may find ````autoDelete: true```` useful in place of durable if you wish the request queues cleaned up automatically.
+- `prefetch` : default : 1 - Set the prefetch count for this channel. The count given is the maximum number of messages sent over the channel that can be awaiting acknowledgement. To consume multiple requests in the same process, in parallel, this must be set to greater than 1.
 - `logInfo`: Log non-error messages, default console.info - Can pass in custom logger (example Bunyan)
 - `logError`: Log error messages, default console.warn - Can pass in custom logger (example Bunyan)
 
 ## Publisher Options
 
 - `debugLevel`: default: 0 - level 1 will log sent messages, level 2 will also log received messages
-- `replyTimeOutInterval`: default: 3000 - publisher timeout waiting for replies
-- `standalone`: default: false - Close the connection or channel on finish. If used in a server like ExpressJS or KoaJS needs to be true
-- `url`: default: 'localhost'
-- `socketOptions`: default empty Object
+- `replyTimeOutInterval`: default: 3000 milliseconds - publisher timeout waiting for replies
+- `standalone`: default: false - If true, close the connection on finish, otherwise just close the channel.
+- `url`: default: 'localhost' - [A valid amqp URI](https://www.rabbitmq.com/uri-spec.html).
+- `socketOptions`: default empty Object - The socket options will be passed to the socket library (net or tls). The socket options may also include the key noDelay, with a boolean value. If the value is true, this sets TCP_NODELAY on the underlying socket.
 - `queue`: default: 'node_rpc_queue'
-- `logInfo`: Log non-error messages, default console.info - Can pass in custom logger (example Bunyan)
-- `logError`: Log error messages, default console.warn - Can pass in custom logger (example Bunyan)
+- `queueOptions` : default: ````{exclusive: true}```` - AMQP options passed to the queue. You may find ````autoDelete: true```` useful in addition to exclusive if you wish the response queues cleaned up automatically.
+- `logInfo`: Log non-error messages, default console.log - Can pass in custom logger (example Bunyan)
+- `logError`: Log error messages, default console.log - Can pass in custom logger (example Bunyan)
 
 ## Tests
 

--- a/lib/rpc-consumer-factory.js
+++ b/lib/rpc-consumer-factory.js
@@ -4,32 +4,44 @@ var amqp = require('amqplib'),
   _ = require('lodash'),
   q = require('q');
 
+var logInfoDefault = function(msg) {
+  console.log(msg);
+}
+
+var logErrorDefault = function(msg) {
+  console.log(msg);
+}
+
+var processMessageDefault = function(msg) {
+  var input = msg.content.toString();
+  this.logInfo('Consumer RPC input: ' + input);
+  return input + '-OK';
+}
+
 var rpcConsumerProto = {
 
-  connectionRetryInterval: 500,
-
-  url: 'localhost',
-
-  socketOptions: {},
-
-  queue: 'node_rpc_queue',
-
-  logInfo: function(msg) {
-    console.log(msg);
-  },
-
-  logError: function(msg) {
-    console.log(msg);
-  },
-
   uri: function () {
+    if(_.startsWith('amqp://') || _.startsWith('amqps://')) {
+      return this.url;
+    }
     return ['amqp://', this.url].join('');
   },
 
-  processMessage: function(msg) {
-    var input = msg.content.toString();
-    this.logInfo('Consumer RPC input: ' + input);
-    return input + '-OK';
+  init : function(options) {
+    options = options || {};
+    this.connectionRetryInterval  = options.connectionRetryInterval || 500;
+    this.url = options.url || 'localhost';
+    this.socketOptions = options.socketOptions || {};
+    this.queue = options.queue || 'node_rpc_queue';
+    this.queueOptions = options.queueOptions || {durable: true};
+    this.prefetch = options.prefetch || 1;
+
+    this.logInfo = options.logInfo || logInfoDefault;
+    this.logError = options.logError || logErrorDefault;
+
+    this.processMessage = options.processMessage || processMessageDefault;
+
+    return this;
   },
 
   connect: function () {
@@ -66,13 +78,12 @@ var rpcConsumerProto = {
 
         }
 
-        return ch.assertQueue(this.queue, {durable: true})
+        return ch.assertQueue(this.queue, this.queueOptions)
           .then(function assertQueueSuccess() {
-            ch.prefetch(1);
+            ch.prefetch(this.prefetch);
             return ch.consume(this.queue, Reply.bind(this));
           }.bind(this))
           .then(function consumeSuccess() {
-            //logger.info([consumerName, env, 'waiting for RPC requests'].join(' '));
             this.logInfo('Consumer: Waiting for RPC requests on: ' + this.queue);
           }.bind(this));
 
@@ -95,5 +106,5 @@ var rpcConsumerProto = {
 };
 
 exports.create = function(options) {
-  return Object.create(_.extend(rpcConsumerProto, options || {}));
+  return Object.create(rpcConsumerProto).init(options);
 };

--- a/lib/rpc-consumer-factory.js
+++ b/lib/rpc-consumer-factory.js
@@ -21,7 +21,7 @@ var processMessageDefault = function(msg) {
 var rpcConsumerProto = {
 
   uri: function () {
-    if(_.startsWith('amqp://') || _.startsWith('amqps://')) {
+    if(this.url.slice(0, 7) == 'amqp://' || this.url.slice(0, 8) == 'amqps://') {
       return this.url;
     }
     return ['amqp://', this.url].join('');

--- a/lib/rpc-publisher-factory.js
+++ b/lib/rpc-publisher-factory.js
@@ -16,7 +16,7 @@ var logErrorDefault = function(msg) {
 
 var rpcPublisherProto = {
   uri: function () {
-    if(_.startsWith('amqp://', this.url) || _.startsWith('amqps://', this.url)) {
+    if(this.url.slice(0, 7) == 'amqp://' || this.url.slice(0, 8) == 'amqps://') {
       return this.url;
     }
     return ['amqp://', this.url].join('');

--- a/lib/rpc-publisher-factory.js
+++ b/lib/rpc-publisher-factory.js
@@ -16,7 +16,7 @@ var logErrorDefault = function(msg) {
 
 var rpcPublisherProto = {
   uri: function () {
-    if(_.startsWith('amqp://') || _.startsWith('amqps://')) {
+    if(_.startsWith('amqp://', this.url) || _.startsWith('amqps://', this.url)) {
       return this.url;
     }
     return ['amqp://', this.url].join('');

--- a/lib/rpc-publisher-factory.js
+++ b/lib/rpc-publisher-factory.js
@@ -6,37 +6,40 @@ var amqp = require('amqplib'),
   uuid = require('uuid'),
   domain = require('domain');
 
+var logInfoDefault = function(msg) {
+  console.log(msg);
+}
+
+var logErrorDefault = function(msg) {
+  console.log(msg);
+}
+
 var rpcPublisherProto = {
-
-  debugLevel: 0,
-
-  replyTimeOutInterval: 3000,
-
-  standalone: false,
-
-  connection: null,
-
-  url: 'localhost',
-
-  socketOptions: {},
-
-  queue: 'node_rpc_queue',
-
-  logInfo: function (msg) {
-    console.info(msg);
-  },
-
-  logError: function (msg) {
-    console.warn(msg);
-  },
-
   uri: function () {
+    if(_.startsWith('amqp://') || _.startsWith('amqps://')) {
+      return this.url;
+    }
     return ['amqp://', this.url].join('');
   },
-
   publisherDomain: domain.create(),
 
-  currentConnection: null,
+  init : function (options) {
+    options = options || {};
+    this.replyTimeOutInterval  = options.replyTimeOutInterval || 3000;
+    this.url = options.url || 'localhost';
+    this.socketOptions = options.socketOptions || {};
+    this.queue = options.queue || 'node_rpc_queue';
+    this.queueOptions = options.queueOptions || {exclusive: true};
+    this.debugLevel = options.debugLevel || 0;
+    this.standalone = options.standalone || false;
+    this.logInfo = options.logInfo || logInfoDefault;
+    this.logError = options.logError || logErrorDefault;
+
+    this.currentConnection = null;
+    this.connection = null;
+
+    return this;
+  },
 
   publisherDomainOnError: function () {
     this.publisherDomain.on('error', function (err) {
@@ -67,8 +70,10 @@ var rpcPublisherProto = {
     return this.getConnection()
       .then(function connectSuccess(conn) {
 
-        this.currentConnection = conn;
-        this.publisherDomain.add(this.currentConnection);
+        if(_.isNull(this.currentConnection)) {
+          this.currentConnection = conn;
+          this.publisherDomain.add(this.currentConnection);
+        }
 
         return conn.createChannel()
           .then(function createChannelSucces(ch) {
@@ -95,7 +100,7 @@ var rpcPublisherProto = {
               clearTimeout(replyTimeOut);
             }
 
-            return ch.assertQueue('', {exclusive: true})
+            return ch.assertQueue('', this.queueOptions)
               .then(function assertQueueSuccess(qok) {
                 replyQueue = qok.queue;
                 return ch.consume(replyQueue, MaybeAnswer.bind(this), {noAck: true});
@@ -133,6 +138,7 @@ var rpcPublisherProto = {
 
         // Reset the connection
         this.connection = null;
+        this.currentConnection = null;
 
         // Return a rejected promise.
         /**
@@ -153,7 +159,7 @@ var rpcPublisherProto = {
 };
 
 var create = function create(options) {
-  var publisher = Object.create(_.extend(_.clone(rpcPublisherProto), options || {}));
+  var publisher = Object.create(rpcPublisherProto).init(options);
   publisher.publisherDomainOnError();
   return publisher;
 };

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "amqplib": "^0.3.0",
-    "lodash": "^2.4.1",
-    "q": "^1.0.1",
+    "amqplib": "^0.3.1",
+    "lodash": "3.3.1",
+    "q": "^1.1.2",
     "uuid": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Refactor to allow for multiple instances of consumer and publisher to exist. The problem was with Object.create, the resulting object sets a property of a property. When two instances are created, they shared the same properties (e.g. queue, url, etc.). For more reading on this, see [here](http://www.bennadel.com/blog/2184-object-create-improves-constructor-based-inheritance-in-javascript-it-doesn-t-replace-it.htm).
- Added additional options to support configuration, specifically queueOptions, prefetch values, and URI handling. `queueOptions` are important as it allows the setting of "autoDelete" vs "durable" where desired. ``prefetch` is important as it allows the consumer to handle multiple requests at once if the work load calls for it. In an RPC environment, this is often the case as the request is small and quick.
- Package upgrades, amqp.node being the most important as the 0.3.1 patch removes numerous knock on effects. amqp.node v0.3.0 was suffering from a knock-on effect from when.js (as seen here https://github.com/squaremo/amqp.node/commit/63752b1d253e058ed3d6f38ca39ffecb74ae8e50). This effect manifested itself only under heavier load, which is difficult to test, but easier to find in production.
- Update README.md to provide additional options and more detailed explanation of them.
