### PR TITLE
Handle disconnections in non-standalone mode

### DIFF
--- a/lib/rpc-publisher-factory.js
+++ b/lib/rpc-publisher-factory.js
@@ -69,7 +69,13 @@ var rpcPublisherProto = {
 
     return this.getConnection()
       .then(function connectSuccess(conn) {
-
+        if (!this.standalone) {
+          conn.on('error', function (err) {
+            this.logError(err.stack);
+            this.connection = null;
+            this.publisherDomain.remove(this.currentConnection);
+          }.bind(this));
+        }
         if (_.isNull(this.currentConnection)) {
           this.currentConnection = conn;
           this.publisherDomain.add(this.currentConnection);

--- a/lib/rpc-publisher-factory.js
+++ b/lib/rpc-publisher-factory.js
@@ -74,6 +74,7 @@ var rpcPublisherProto = {
             this.logError(err.stack);
             this.connection = null;
             this.publisherDomain.remove(this.currentConnection);
+            conn.removeAllListeners('error');
           }.bind(this));
         }
         if (_.isNull(this.currentConnection)) {


### PR DESCRIPTION
the publish must re-create the connection if it's lost in non-standalone mode. Otherwise the software will crash.

I don't know why but, with amqplib, publisherDomain can't intercept this kind of error and conn.on('error',...) must be used.
