### PR TITLE
feat(connection): make possible to use external RabbitMQ connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Check out the [examples](examples) for more details of the basic, advanced, adva
 - `prefetch` : default : 1 - Set the prefetch count for this channel. The count given is the maximum number of messages sent over the channel that can be awaiting acknowledgement. To consume multiple requests in the same process, in parallel, this must be set to greater than 1.
 - `logInfo`: Log non-error messages, default console.info - Can pass in custom logger (example Bunyan)
 - `logError`: Log error messages, default console.warn - Can pass in custom logger (example Bunyan)
+- `connection`: default: auto connect by `url` and `socketOptions` - [amqplib](https://www.npmjs.com/package/amqplib) connection, reconnect should be handled manually in this case via  `initConsumer(connection)`
 
 ## Publisher Options
 
@@ -117,6 +118,7 @@ Check out the [examples](examples) for more details of the basic, advanced, adva
 - `queueOptions` : default: ````{exclusive: true, autoDelete: true}```` - AMQP options passed to the queue.
 - `logInfo`: Log non-error messages, default console.log - Can pass in custom logger (example Bunyan)
 - `logError`: Log error messages, default console.log - Can pass in custom logger (example Bunyan)
+- `connection`: default: auto connect by `url` and `socketOptions` - [amqplib](https://www.npmjs.com/package/amqplib) connection
 
 ## Tests
 

--- a/lib/rpc-consumer-factory.js
+++ b/lib/rpc-consumer-factory.js
@@ -40,53 +40,25 @@ var rpcConsumerProto = {
 
     this.processMessage = options.processMessage || processMessageDefault;
 
+    this.connection = null;
+
     return this;
   },
 
   connect: function () {
+    if (this.connection) {
+      return this.initConsumer(conn);
+    }
 
-    amqp.connect(this.uri(), this.socketOptions).then(function getConnectionSuccess(conn) {
+    return amqp.connect(this.uri(), this.socketOptions).then(function getConnectionSuccess(conn) {
 
       conn.on('error', function (err) {
         this.logError(err.stack);
         this.reconnect();
       }.bind(this));
 
-      return conn.createChannel().then(function createChannelSuccess(ch) {
+      return this.initConsumer(conn);
 
-        // Capitalize this function as its used with a this binding
-        function Reply(msg) {
-
-          // process request
-          var response;
-
-          // If this.processMessage is a Q promise, returns the promise.
-          // If this.processMessage is not a promise, returns a promise that is fulfilled with value.
-          q(this.processMessage(msg))
-            .then(function processMessageSuccess(res) {
-              response = res;
-            })
-            .catch(function processMessageError(err) {
-              response = err;
-            })
-            .finally(function () {
-              // send response
-              ch.sendToQueue(msg.properties.replyTo, new Buffer(response.toString()), {correlationId: msg.properties.correlationId});
-              ch.ack(msg);
-            });
-
-        }
-
-        return ch.assertQueue(this.queue, this.queueOptions)
-          .then(function assertQueueSuccess() {
-            ch.prefetch(this.prefetch);
-            return ch.consume(this.queue, Reply.bind(this));
-          }.bind(this))
-          .then(function consumeSuccess() {
-            this.logInfo('Consumer: Waiting for RPC requests on: ' + this.queue);
-          }.bind(this));
-
-      }.bind(this));
     }.bind(this))
       .catch(function (error) {
         this.logError('Consumer: AMQP Connect Error: ' + error.stack);
@@ -99,8 +71,46 @@ var rpcConsumerProto = {
     setTimeout(this.connect.bind(this), this.connectionRetryInterval);
   },
 
+  initConsumer: function (conn) {
+    return conn.createChannel().then(function createChannelSuccess(ch) {
+
+      // Capitalize this function as its used with a this binding
+      function Reply(msg) {
+
+        // process request
+        var response;
+
+        // If this.processMessage is a Q promise, returns the promise.
+        // If this.processMessage is not a promise, returns a promise that is fulfilled with value.
+        q(this.processMessage(msg))
+          .then(function processMessageSuccess(res) {
+            response = res;
+          })
+          .catch(function processMessageError(err) {
+            response = err;
+          })
+          .finally(function () {
+            // send response
+            ch.sendToQueue(msg.properties.replyTo, new Buffer(response.toString()), {correlationId: msg.properties.correlationId});
+            ch.ack(msg);
+          });
+
+      }
+
+      return ch.assertQueue(this.queue, this.queueOptions)
+        .then(function assertQueueSuccess() {
+          ch.prefetch(this.prefetch);
+          return ch.consume(this.queue, Reply.bind(this));
+        }.bind(this))
+        .then(function consumeSuccess() {
+          this.logInfo('Consumer: Waiting for RPC requests on: ' + this.queue);
+        }.bind(this));
+
+    }.bind(this));
+  },
+
   run: function () {
-    this.connect();
+    return this.connect();
   }
 };
 


### PR DESCRIPTION
- [x] allow external `connection` object in consumer
- [x] document external `connection` object in publisher
