### PR TITLE
Better reconnecting logic

### DIFF
--- a/lib/rpc-consumer-factory.js
+++ b/lib/rpc-consumer-factory.js
@@ -46,11 +46,6 @@ var rpcConsumerProto = {
   connect: function () {
 
     amqp.connect(this.uri(), this.socketOptions).then(function getConnectionSuccess(conn) {
-
-      conn.on('error', function (err) {
-        this.logError(err.stack);
-        this.reconnect();
-      }.bind(this));
       
       conn.on('close', function (err) {
         this.logError(err.stack);

--- a/lib/rpc-consumer-factory.js
+++ b/lib/rpc-consumer-factory.js
@@ -51,6 +51,11 @@ var rpcConsumerProto = {
         this.logError(err.stack);
         this.reconnect();
       }.bind(this));
+      
+      conn.on('close', function (err) {
+        this.logError(err.stack);
+        this.reconnect();
+      }.bind(this));
 
       return conn.createChannel().then(function createChannelSuccess(ch) {
 

--- a/lib/rpc-publisher-factory.js
+++ b/lib/rpc-publisher-factory.js
@@ -77,11 +77,6 @@ var rpcPublisherProto = {
               this.connection = null;
               this.currentConnection = null;
             });
-
-            conn.on('error', function (err) {
-              this.connection = null;
-              this.currentConnection = null;
-            });
           }
           this.publisherDomain.add(this.currentConnection);
         }

--- a/lib/rpc-publisher-factory.js
+++ b/lib/rpc-publisher-factory.js
@@ -72,6 +72,15 @@ var rpcPublisherProto = {
 
         if (_.isNull(this.currentConnection)) {
           this.currentConnection = conn;
+          conn.on('close', function (err) {
+              this.connection = null;
+              this.currentConnection = null;
+            });
+
+          conn.on('error', function (err) {
+            this.connection = null;
+            this.currentConnection = null;
+          });
           this.publisherDomain.add(this.currentConnection);
         }
 

--- a/lib/rpc-publisher-factory.js
+++ b/lib/rpc-publisher-factory.js
@@ -72,15 +72,17 @@ var rpcPublisherProto = {
 
         if (_.isNull(this.currentConnection)) {
           this.currentConnection = conn;
-          conn.on('close', function (err) {
+          if (this.standalone === false) {
+            conn.on('close', function (err) {
               this.connection = null;
               this.currentConnection = null;
             });
 
-          conn.on('error', function (err) {
-            this.connection = null;
-            this.currentConnection = null;
-          });
+            conn.on('error', function (err) {
+              this.connection = null;
+              this.currentConnection = null;
+            });
+          }
           this.publisherDomain.add(this.currentConnection);
         }
 


### PR DESCRIPTION
Hi, 

using your library in production I want to improve the reconnecting logic.

in the consumer i changed error event to close because close will be always called after error. But error alone does not handle broker restart. 

and in the publisher, when is not standalone I watch for connections error in order to reset the connection. 

Thank you